### PR TITLE
Retour recette problème affichage erreur et date fin de contrat

### DIFF
--- a/src/views/connected/admin/contrats/ConseillerDetailsContrat.js
+++ b/src/views/connected/admin/contrats/ConseillerDetailsContrat.js
@@ -11,6 +11,7 @@ import ModalValidationRenouvellement from '../modals/ModalValidationRenouvelleme
 import PopinEditionContrat from '../../../connected/structure/popins/popinEditionContrat';
 import InformationConseiller from '../../../../components/InformationConseiller';
 import StructureContactCards from '../../../../components/cards/StructureContactCards';
+import { scrollTopWindow } from '../../../../utils/exportsUtils';
 
 function ConseillerDetailsContrat() {
 
@@ -29,9 +30,11 @@ function ConseillerDetailsContrat() {
   const [misesEnRelationFinalisee, setMisesEnRelationFinalisee] = useState([]);
   const [misesEnRelationNouvelleRupture, setMisesEnRelationNouvelleRupture] = useState(null);
   const [misesEnRelationFinaliseeRupture, setMisesEnRelationFinaliseeRupture] = useState([]);
+  const [dateFinDeContratInitiale, setDateFinDeContratInitiale] = useState(null);
   const [dateFinDeContrat, setDateFinDeContrat] = useState(null);
   const [openModal, setOpenModal] = useState(false);
   const [openModalContrat, setOpenModalContrat] = useState(false);
+  const [afficherErreur, setAfficherErreur] = useState(false);
 
   useEffect(() => {
     if (!errorConseiller) {
@@ -55,6 +58,7 @@ function ConseillerDetailsContrat() {
         setMisesEnRelationNouvelleRupture(miseEnRelation);
         setMisesEnRelationFinaliseeRupture(conseiller.misesEnRelation.filter(miseEnRelation => miseEnRelation.statut === 'finalisee_rupture'));
         setDateFinDeContrat(miseEnRelation?.dateRupture ? new Date(miseEnRelation.dateRupture) : null);
+        setDateFinDeContratInitiale(miseEnRelation?.dateFinDeContrat ? new Date(miseEnRelation.dateFinDeContrat) : null);
         if (conseiller?.statut !== 'RUPTURE') {
           dispatch(structureActions.get(conseiller?.structureId));
         }
@@ -68,6 +72,16 @@ function ConseillerDetailsContrat() {
     }
   }, [conseiller, errorStructure]);
 
+  useEffect(() => {
+    if (errorRupture || errorContrat) {
+      scrollTopWindow();
+      setAfficherErreur(errorRupture || errorContrat);
+      setTimeout(() => {
+        setAfficherErreur(false);
+      }, 5000);
+    }
+  }, [errorRupture, errorContrat]);
+
   const updateContract = (typeDeContrat, dateDebut, dateFin, salaire) => {
     dispatch(contratActions.updateContract(typeDeContrat, dateDebut, dateFin, salaire, conseiller?.contrat?._id));
   };
@@ -80,17 +94,10 @@ function ConseillerDetailsContrat() {
         className="fr-btn fr-btn--sm fr-fi-arrow-left-line fr-btn--icon-left fr-btn--tertiary">
         Retour &agrave; la liste
       </button>
-      {errorRupture &&
+      {afficherErreur &&
         <div className="fr-alert fr-alert--error fr-mt-4w">
           <p className="fr-alert__title">
-            {errorRupture}
-          </p>
-        </div>
-      }
-      {errorContrat &&
-        <div className="fr-alert fr-alert--error fr-mt-4w">
-          <p className="fr-alert__title">
-            {errorContrat}
+            {afficherErreur}
           </p>
         </div>
       }
@@ -124,6 +131,7 @@ function ConseillerDetailsContrat() {
           <h5 className="fr-h5 fr-mb-3v">ID - {conseiller?.idPG ?? ''}</h5>
         </div>
       </div>
+      {errorRupture}
       {conseiller &&
         <>
           <div className="fr-col-12 fr-grid-row" style={{ alignItems: 'baseline' }}>
@@ -151,6 +159,7 @@ function ConseillerDetailsContrat() {
                   dateFinDeContrat={dateFinDeContrat}
                   setDateFinDeContrat={setDateFinDeContrat}
                   datePrisePoste={conseiller?.datePrisePoste}
+                  dateFinDeContratInitiale={dateFinDeContratInitiale}
                 />
               }
             </>

--- a/src/views/connected/admin/modals/ModalValidationRupture.js
+++ b/src/views/connected/admin/modals/ModalValidationRupture.js
@@ -8,7 +8,7 @@ import { formatMotifRupture } from '../../../../utils/formatagesUtils';
 
 //Print datePicker calendar in FR
 registerLocale('fr', fr);
-function ModalValidationRupture({ setOpenModal, miseEnRelation, datePrisePoste, dateFinDeContrat, setDateFinDeContrat }) {
+function ModalValidationRupture({ setOpenModal, miseEnRelation, datePrisePoste, dateFinDeContrat, setDateFinDeContrat, dateFinDeContratInitiale }) {
   const [confirmationRupture, setConfirmationRupture] = useState(false);
   const [dossierComplet, setDossierComplet] = useState(null);
   const dispatch = useDispatch();
@@ -79,7 +79,7 @@ function ModalValidationRupture({ setOpenModal, miseEnRelation, datePrisePoste, 
                         peekNextMonth
                         onChangeRaw={e => e.preventDefault()}
                         minDate={new Date(datePrisePoste)}
-                        maxDate={new Date()}
+                        maxDate={new Date(dateFinDeContratInitiale)}
                       />
                     </div>
                     <div className="fr-col-12 fr-mt-1w">
@@ -186,6 +186,7 @@ ModalValidationRupture.propTypes = {
   miseEnRelation: PropTypes.object,
   setOpenModal: PropTypes.func,
   setDateFinDeContrat: PropTypes.func,
+  dateFinDeContratInitiale: PropTypes.instanceOf(Date),
 };
 
 export default ModalValidationRupture;


### PR DESCRIPTION
Les messages d'erreurs ne s'affichent pas lorsque l'on en rencontre une dans le formulaire de déclaration de rupture (popin)
Le calendrier bloque à la date du jour au lieu de bloquer à partir de la date de fin de contrat inclus.